### PR TITLE
Warning fix with _CRT_SECURE_NO_WARNINGS

### DIFF
--- a/flecs_dash.h
+++ b/flecs_dash.h
@@ -1,3 +1,7 @@
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #define flecs_dash_STATIC
 #ifndef FLECS_DASH_H
 #define FLECS_DASH_H

--- a/include/flecs_dash.h
+++ b/include/flecs_dash.h
@@ -1,3 +1,7 @@
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #ifndef FLECS_DASH_H
 #define FLECS_DASH_H
 


### PR DESCRIPTION
if using MSVC it will turn off the deprecation errors when not using _s functions 
